### PR TITLE
Added special case for converting bit columns to logical, regarding bug #47

### DIFF
--- a/R/dbi-methods.R
+++ b/R/dbi-methods.R
@@ -365,8 +365,14 @@ setMethod("fetch", c("SQLServerResult", "numeric"),
       cnames <- colnames(df)
       names(rcts) <- cnames
       for (cname in cnames[to_convert]) {
-        f <- paste0("as.", unname(rcts[cname]))
-        df[, cname] <- eval(call(f, df[, cname]))
+        # special case for bit columns,
+        # which become character vectors of "0" and "1"
+        if (rcts[cname] == "logical") {
+          df[, cname] <- as.logical(as.numeric(df[, cname]))
+        } else {
+          f <- paste0("as.", unname(rcts[cname]))
+          df[, cname] <- eval(call(f, df[, cname]))
+        }
       }
     }
     df


### PR DESCRIPTION
This is because JDBC's fetch method returns "0" and "1" as a character column rather than numeric, such that `as.logical` converts them to NAs.

I believe this fixes #47 (at least, it does in my use case). By using `as.logical(as.numeric(`, it should also be robust to cases where JDBC does return a numeric column (because of, for example, some difference between platforms or versions).