### PR TITLE
Feature dbi 0 5 multibind

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,8 @@ Authors@R: c(person("Imanuel", "Costigan", role = c("aut", "cre"),
                     role = "ctb"),
              person("Romain", "Francois", email = "romain@r-enthusiasts.com",
                     role = "ctb"),
-             person("Bill", "Evans", email = "bill@8pawsexpress.com", role = "ctb"),
+             person("Bill", "Evans", email = "bill@8pawsexpress.com",
+                    role = "ctb"),
              person("RStudio", role = "cph"),
              person("The Legion Of The Bouncy Castle", role = c("cph", "ctb")))
 Description: Utilises The jTDS Project's JDBC 3.0 SQL Server

--- a/NEWS.md
+++ b/NEWS.md
@@ -44,7 +44,7 @@ SQL Server (#75)
 
 - Implemented `dbBegin()`, `dbCommit()`, `dbRollback()` methods and use these in `dbWriteTable()`
 - `dbWriteTable()` now fails when attempting to append to a temporary table (#75)
-- Implemented `dbSendStatement()` method which required the extension of `SQLServerResult` to `SQLServerUpdateResult` the latter of which is used to dispatch the `dbGetRowsAffected()` method. (#95)
+- Implemented `dbSendStatement()` method which required the extension of `SQLServerResult` to `SQLServerUpdateResult` the latter of which is used to dispatch the `dbGetRowsAffected()` method (#95). Added `batch` option to both `dbSendStatement()` and `dbSendQuery` for insert/update speedup (#69, #90, #106, @r2evans).
 - Implemented `dbBind()` method to replace the internal `.fillStatementParameter()` method which required the extension of `SQLServerResult` to `SQLServerPreResult` the latter of which allows statements with bindings to present a ResultSet interface to DBI (ResultSets are only created after values are bound to parameterised statements in JDBC). (#88)
 - Implemented `sqlCreateTable()` for `SQLServerConnection` which is called by `db_create_table()`. (#76)
 - `dbDataType` maps R character objects of sufficiently long length to `VARCHAR(MAX)` on newer version of MSSQL rather than `TEXT` as the latter is being deprecated.
@@ -57,7 +57,6 @@ SQL Server (#75)
 - `dbIsValid()` implemented for `SQLServerDriver` and always returns `TRUE`.
 - Now rely on DBI supplied `show()` methods
 - Added Travis-CI (#83, #84) and Appveyor support (#80, @Hong-Revo)
-- added `dbSendStatement(..., batch = TRUE)` for insert/update speedup
 
 # Version 0.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -57,6 +57,7 @@ SQL Server (#75)
 - `dbIsValid()` implemented for `SQLServerDriver` and always returns `TRUE`.
 - Now rely on DBI supplied `show()` methods
 - Added Travis-CI (#83, #84) and Appveyor support (#80, @Hong-Revo)
+- added `dbSendStatement(..., batch = TRUE)` for insert/update speedup
 
 # Version 0.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,8 +28,8 @@ A number of changes have been made to improve DBI compliance as specified by tes
 A number of changes were made to dplyr backend. As a result, dplyr >= 0.5 is required. Most changes are not visible to users. However, the following are of note:
 
 - Implemented `db_create_table()`, `db_insert_into()` and `db_create_index()` for SQLServerConnection
-- Updated `db_drop_table()` to support `IF EXISTS` SQL clause if supported by 
-SQL Server (#75)
+- Updated `db_drop_table()` to support `IF EXISTS` SQL clause if supported by SQL Server (#75)
+- `copy_to()` is now much faster due to the `batch` and transaction changes, listed below in "Other changes"
 - New `temporary` argument to `db_insert_into()` which overwrites existing table if set to `TRUE` and if necessary. 
 - `db_query_fields()` method for SQLServerConnection removed in favour of default dplyr method. The latter better handles sub-queries.
 - `sql_select()` method supports the `DISTINCT` keyword and includes `TOP` keyword when query results are ordered.
@@ -45,7 +45,9 @@ SQL Server (#75)
 - Implemented `dbBegin()`, `dbCommit()`, `dbRollback()` methods and use these in `dbWriteTable()`
 - `dbWriteTable()` now fails when attempting to append to a temporary table (#75)
 - Implemented `dbSendStatement()` method which required the extension of `SQLServerResult` to `SQLServerUpdateResult` the latter of which is used to dispatch the `dbGetRowsAffected()` method (#95). Added `batch` option to both `dbSendStatement()` and `dbSendQuery` for insert/update speedup (#69, #90, #106, @r2evans).
+- `dbWriteTable()` is faster by always using transactions (`BEGIN` before and `COMMIT` after), and optionally much faster by way of the `batch` option.
 - Implemented `dbBind()` method to replace the internal `.fillStatementParameter()` method which required the extension of `SQLServerResult` to `SQLServerPreResult` the latter of which allows statements with bindings to present a ResultSet interface to DBI (ResultSets are only created after values are bound to parameterised statements in JDBC). (#88)
+- `dbBind()` now supports multi-row binding (e.g., for `INSERT` and `UPDATE`)
 - Implemented `sqlCreateTable()` for `SQLServerConnection` which is called by `db_create_table()`. (#76)
 - `dbDataType` maps R character objects of sufficiently long length to `VARCHAR(MAX)` on newer version of MSSQL rather than `TEXT` as the latter is being deprecated.
 - Arguments of `dbConnect()` are now `NULL` where other default values were assigned. This does not change the behaviour of the method.

--- a/R/Utils.R
+++ b/R/Utils.R
@@ -192,7 +192,7 @@ rs_bind_all <- function(params, rs, batch = TRUE) {
 
 ps_bind_all <- function(params, ps, batch = TRUE) {
   paramlengths <- vapply(params, length, integer(1L))
-  if (! batch && any(paramlengths > 1L)) {
+  if (!batch && any(paramlengths > 1L)) {
     warning("'batch' disabled with multi-row params, only first of each param applied",
       call. = FALSE)
   }
@@ -203,7 +203,7 @@ ps_bind_all <- function(params, ps, batch = TRUE) {
   is_numeric <- vapply(params, is.numeric, logical(1))
   is_date <- vapply(params, inherits, logical(1), "Date")
   is_posix <- vapply(params, inherits, logical(1), "POSIXct")
-  is_other <- ! (is_logical | is_numeric | is_date | is_posix)
+  is_other <- !(is_logical | is_numeric | is_date | is_posix)
 
   jtypes <- rToJdbcType(vapply(params, function(a) class(a)[1], character(1)))
 

--- a/R/dbi-methods.R
+++ b/R/dbi-methods.R
@@ -170,14 +170,7 @@ setMethod("dbSendQuery", c("SQLServerConnection", "character"),
     if (is_parameterised(ps) && is.null(params)) {
       return(pre_res)
     } else {
-      qry_nparams <- num_parameters(ps)
-      nparams <- length(params)
-      if (qry_nparams > 0 && nparams > 0L) {
-        if (nparams > qry_nparams) {
-          params <- params[1:qry_nparams]
-        }
-        dbBind(pre_res, params, batch = batch)
-      }
+      dbBind(pre_res, params, batch = batch)
       jr <- execute_query(pre_res@stat)
       catch_exception(jr, "Unable to retrieve result set for ", statement)
       md <- rs_metadata(jr, FALSE)

--- a/R/dbi-methods.R
+++ b/R/dbi-methods.R
@@ -146,6 +146,9 @@ setMethod("dbDisconnect", "SQLServerConnection", function (conn, ...) {
   }
 })
 
+#' @param batch logical, indicates whether uploads (e.g., 'INSERT' or
+#'   'UPDATE') should be uploaded in batches, potentially much faster
+#'   than by individual rows (the default).
 #' @rdname SQLServerConnection-class
 #' @export
 
@@ -444,6 +447,12 @@ setMethod("fetch", c("SQLServerPreResult", "numeric"),
     fetch(new("SQLServerResult", res, jr = jr, md = md), n)
 })
 
+#' @param batch logical, indicates whether uploads (e.g., 'INSERT' or
+#'   'UPDATE') should be uploaded in batches, potentially much faster
+#'   than by individual rows (the default). (Setting it here enabled
+#'   binding the variables in batches, the actual batched upload is
+#'   done in \code{\link{dbSendStatement}} or
+#'   \code{\link{dbExecute}}.)
 #' @rdname SQLServerResult-class
 #' @export
 setMethod("dbBind", "SQLServerPreResult", function(res, params, ..., batch = FALSE) {

--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -74,22 +74,18 @@ copy_to.src_sqlserver <- function (dest, df, name = NULL, types = NULL,
   types <- types %||% db_data_type(dest$con, df)
   names(types) <- names(df)
   con <- dest$con
-  db_begin(con)
-  on.exit(db_rollback(con))
   name <- db_create_table(con, name, types, temporary = temporary)
   db_insert_into(con, name, df, temporary = temporary)
   db_create_indexes(con, name, unique_indexes, unique = TRUE)
   db_create_indexes(con, name, indexes, unique = FALSE)
   # SQL Server doesn't have ANALYZE TABLE support so this part of
   # copy_to.src_sql has been dropped
-  db_commit(con)
-  on.exit(NULL)
   tbl(dest, name)
 }
 
 
 #' @importFrom dplyr compute op_vars select_ sql_render tbl group_by_ groups
-#' @importFrom dplyr db_create_indexes %>% db_begin db_rollback db_commit
+#' @importFrom dplyr db_create_indexes %>%
 #' @export
 compute.tbl_sqlserver <- function(x, name = random_table_name(), temporary = TRUE,
   unique_indexes = list(), indexes = list(), ...) {

--- a/R/java-shims.R
+++ b/R/java-shims.R
@@ -59,6 +59,10 @@ execute_update <- function(statement, string = NULL, check = FALSE) {
   }
 }
 
+execute_batch <- function(statement, check = FALSE) {
+  rJava::.jcall(statement, "[I", "executeBatch", check = check)
+}
+
 rs_metadata <- function(res, check = FALSE) {
   rJava::.jcall(res, "Ljava/sql/ResultSetMetaData;", "getMetaData",
     check = check)
@@ -74,4 +78,8 @@ catch_exception <- function (object, ...) {
     else
       stop(..., ": ", rJava::.jcall(x, "S", "getMessage"), call. = FALSE)
   }
+}
+
+is_autocommit <- function(conn, check = FALSE) {
+  rJava::.jcall(conn@jc, "Z", "getAutoCommit", check = check)
 }

--- a/man/SQLServerConnection-class.Rd
+++ b/man/SQLServerConnection-class.Rd
@@ -28,7 +28,7 @@
 \S4method{dbDisconnect}{SQLServerConnection}(conn, ...)
 
 \S4method{dbSendQuery}{SQLServerConnection,character}(conn, statement,
-  params = NULL, ...)
+  params = NULL, ..., batch = FALSE)
 
 \S4method{dbSendStatement}{SQLServerConnection,character}(conn, statement,
   params = NULL, ..., batch = FALSE)
@@ -52,7 +52,7 @@ dbSendUpdate(conn, statement, ...)
 \S4method{dbRollback}{SQLServerConnection}(conn, ...)
 
 \S4method{dbWriteTable}{SQLServerConnection}(conn, name, value,
-  overwrite = TRUE, append = FALSE)
+  overwrite = TRUE, append = FALSE, batch = FALSE)
 
 \S4method{sqlCreateTable}{SQLServerConnection}(con, table, fields,
   row.names = NA, temporary = FALSE, ...)

--- a/man/SQLServerConnection-class.Rd
+++ b/man/SQLServerConnection-class.Rd
@@ -31,7 +31,7 @@
   params = NULL, ...)
 
 \S4method{dbSendStatement}{SQLServerConnection,character}(conn, statement,
-  params = NULL, ...)
+  params = NULL, ..., batch = FALSE)
 
 dbSendUpdate(conn, statement, ...)
 
@@ -56,6 +56,11 @@ dbSendUpdate(conn, statement, ...)
 
 \S4method{sqlCreateTable}{SQLServerConnection}(con, table, fields,
   row.names = NA, temporary = FALSE, ...)
+}
+\arguments{
+\item{batch}{logical, indicates whether uploads (e.g., 'INSERT' or
+'UPDATE') should be uploaded in batches, potentially much faster
+than by individual rows (the default).}
 }
 \description{
 SQL Server Connection class

--- a/man/SQLServerResult-class.Rd
+++ b/man/SQLServerResult-class.Rd
@@ -26,7 +26,7 @@
 
 \S4method{fetch}{SQLServerPreResult,numeric}(res, n = -1, ...)
 
-\S4method{dbBind}{SQLServerPreResult}(res, params, ...)
+\S4method{dbBind}{SQLServerPreResult}(res, params, ..., batch = FALSE)
 
 \S4method{dbFetch}{SQLServerResult,numeric}(res, n = -1, ...)
 
@@ -47,6 +47,14 @@
 \S4method{dbGetRowsAffected}{SQLServerUpdateResult}(res, ...)
 
 \S4method{dbHasCompleted}{SQLServerResult}(res, ...)
+}
+\arguments{
+\item{batch}{logical, indicates whether uploads (e.g., 'INSERT' or
+'UPDATE') should be uploaded in batches, potentially much faster
+than by individual rows (the default). (Setting it here enabled
+binding the variables in batches, the actual batched upload is
+done in \code{\link{dbSendStatement}} or
+\code{\link{dbExecute}}.)}
 }
 \description{
 The \code{SQLServerPreResult} class extends the \code{DBIResult} class, the


### PR DESCRIPTION
Fixes  #69, #90, #106. Obviates (I think) #103. (This is a simpler patch than #109.)

Changes proposed:

- use `dbWithTransaction` in `dbWriteTable` only
- added `batch` option to many funcs, using `addBatch` and `executeBatch` jTDS methods

Performance speedup to writes (over an ssh tunnel):

|    n| old-dbWriteTable| new-dbWriteTable|dbExecuteNoBatch| dbExecuteBatch|
|----:|------------:|-----------:|---------:|---------:|
|   10|         3.64|        2.39 | 1.22 | 0.30|
|  100|        32.09|       12.91 | 11.43 | 0.95|
| 1000|       308.94|      120.37 | 113.79 | 7.50|

`n` is number of rows sent. Tested with a data.frame structured like:

|lgl   | numi|      numf|chr |psx                 |dte        |
|:-----|----:|---------:|:---|:-------------------|:----------|
|TRUE  |    1| 0.9693283|'Q" |2016-09-19 05:09:30 |2016-10-07 |
|FALSE |   82| 0.3395904|'P" |2016-09-19 04:29:13 |2016-12-06 |

@imanuelcostigan
