### PR TITLE
Fix version check for MSSQL 2000

### DIFF
--- a/R/sql-backends.R
+++ b/R/sql-backends.R
@@ -107,7 +107,7 @@ mssql_top <- function (con, n, is_percent = NULL) {
   # https://msdn.microsoft.com/en-us/library/ms189463(v=sql.90).aspx
   assertthat::assert_that(assertthat::is.number(n), n >= 0)
   n <- as.integer(n)
-  is_mssql_2000 <- dbGetInfo(con)$db.version == 8
+  is_mssql_2000 <- grepl("^8\\.", dbGetInfo(con)$db.version)
   if (is.null(is_percent) || !isTRUE(is_percent)) {
     if (!is_mssql_2000) n <- escape(n, parens = TRUE)
     return(build_sql("TOP ", n))


### PR DESCRIPTION
Fixes #122 .


Changes proposed:

- Beginning of version number is now checked for 8. using grepl.

@imanuelcostigan

Fixes problem in sql-backends where the
version number was checked to be exactly 8
rather than checking the beginning of the
version number.